### PR TITLE
arduino code refactoring

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -126,6 +126,7 @@
 
 - ✅ Hardened systemd deployment: default exec driver uses shell + `sudo -n`, service update target added, pip cache prepared, and documentation refreshed. Systemd unit keeps `NoNewPrivileges=no` to allow scoped sudo while other hardening flags stay in place.
 - ✅ Arduino resiliency: command view now tracks serial link loss, auto-returns to telemetry on recovery, and shows an animated waiting indicator during outages.
+- ✅ Arduino code quality: centralized LCD sizing constants, split frame commit handling into helpers, and tightened millis()-based watchdog logic.
 - ✅ Python serial resiliency: daemon retries opening the serial port with exponential backoff (5s → 30s capped) and state-aware logging to avoid systemd churn.
 - ☐ Add structured logging + rate-limited error handling in Python daemon (beyond the initial serial backoff).
 - ☐ Expand `/docs` with troubleshooting for hardware disconnects and sudo configuration examples.

--- a/TASKS.md
+++ b/TASKS.md
@@ -64,10 +64,12 @@
 ### Phase 7: Hardening & Docs
 
 - [x] Arduino: recover from serial outages in any mode and show animated “Waiting for data …” indicator.
+- [x] Arduino: replace LCD sizing magic numbers, split `commitFrameIfAny` into helpers, and harden millis() comparisons (`arduino/src/main.cpp`).
 - [ ] Python: adopt structured logging (e.g., JSON adapters) for daemon events.
 - [x] Python: add retry backoff for serial init failures so the service can start before hardware is connected.
 - [ ] Docs: add troubleshooting section covering serial loss recovery and sudo configuration examples.
 - [ ] Instrument daemon with metrics (OpenTelemetry optional) and document monitoring hooks.
+- [ ] Hardware verification pending: confirm LED pulses, command navigation, and frame handling after the refactor on connected hardware.
 
 ### Phase 8: Heartbeat Controller
 

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -147,7 +147,9 @@ def _reader(
                 try:
                     text = line.decode(errors="replace").rstrip()
                     print(f"[arduino] {text}")
-                    _handle_incoming_line(text, ser, cfg, log, allow_exec=allow_exec, exec_driver=exec_driver)
+                    _handle_incoming_line(
+                        text, ser, cfg, log, allow_exec=allow_exec, exec_driver=exec_driver
+                    )
                 except Exception:
                     print(f"[arduino bytes] {line!r}")
         except Exception as e:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -8,4 +8,3 @@ from pathlib import Path
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 if str(PROJECT_DIR) not in sys.path:
     sys.path.insert(0, str(PROJECT_DIR))
-

--- a/server/tests/test_exec.py
+++ b/server/tests/test_exec.py
@@ -42,4 +42,3 @@ def test_select_exec_runs_when_allowed(monkeypatch, caplog) -> None:
     assert called["shell"] is True
     msgs = "\n".join(r.message for r in caplog.records)
     assert "started exec id=2 label=Echo" in msgs
-

--- a/server/tests/test_gpu_fallback.py
+++ b/server/tests/test_gpu_fallback.py
@@ -25,4 +25,3 @@ def test_gpu_summary_uses_nvidia_smi_when_nvml_absent(monkeypatch) -> None:
     assert " 12%" in s
     assert " 25%" in s
     assert " 45C" in s
-

--- a/server/tests/test_validation.py
+++ b/server/tests/test_validation.py
@@ -45,4 +45,3 @@ def test_validate_rejects_empty_join() -> None:
     )
     with pytest.raises(ValueError):
         validate_config(cfg)
-


### PR DESCRIPTION
Centralized LCD geometry and command-label sizing so buffers/string widths no longer depend on magic numbers (arduino/src/main.cpp:13, arduino/src/main.cpp:60).

Split frame handling into parseMetaLine, processTelemetryFrame, processCommandsFrame, and updateWatchdog helpers, turning commitFrameIfAny into a clear dispatcher (arduino/src/main.cpp:183, arduino/src/main.cpp:243).

Synced rendering and heartbeat logic with the shared constants and overflow-safe millis() comparisons, keeping UI updates consistent for telemetry and commands (arduino/src/main.cpp:320, arduino/src/main.cpp:392, arduino/src/main.cpp:465).

Logged the refactor in the phase plan and added a hardware follow-up item so it stays tracked (PROJECT_PLAN.md:129, TASKS.md:67, TASKS.md:72).

make fmt only reformatted a long call and trimmed trailing blank lines in server code; no behavioral changes there (server/src/main.py:150, server/tests/test_exec.py:42).
